### PR TITLE
Planner: thread P.F.T. options through loading + sidebar transforms

### DIFF
--- a/ui/shared/planner/actions/__tests__/loading-actions.1.test.js
+++ b/ui/shared/planner/actions/__tests__/loading-actions.1.test.js
@@ -20,6 +20,7 @@ import {setupServer} from 'msw/node'
 import moment from 'moment-timezone'
 import * as Actions from '../loading-actions'
 import {initialize as alertInitialize} from '../../utilities/alertUtils'
+import {transformApiToInternalItem} from '../../utilities/apiUtils'
 
 vi.mock('../../utilities/apiUtils', async () => ({
   ...(await vi.importActual('../../utilities/apiUtils')),
@@ -193,6 +194,44 @@ describe('api actions', () => {
         response: expect.anything(),
         transformedItems: [{some: 'items', transformedToInternal: true}],
       })
+    })
+
+    it('passes pushForwardTimeOptions to transformApiToInternalItem (observee mode)', async () => {
+      const fromMoment = moment.tz('Asia/Tokyo')
+      let capturedUrl
+      const expectedPushForwardTimeOptions = {enabled: true, hour: 9}
+
+      transformApiToInternalItem.mockClear()
+
+      server.use(
+        http.get('*', ({request}) => {
+          capturedUrl = request.url
+          return new HttpResponse(JSON.stringify([{some: 'items'}]), {
+            status: 200,
+            headers: {'Content-Type': 'application/json'},
+          })
+        }),
+      )
+
+      await Actions.sendFetchRequest({
+        fromMoment,
+        getState: () => ({
+          loading: {},
+          singleCourse: false,
+          courses: [],
+          groups: [],
+          timeZone: 'UTC',
+          selectedObservee: '35',
+          currentUser: {id: '1'},
+          pushForwardTimeOptions: expectedPushForwardTimeOptions,
+        }),
+      })
+
+      const url = new URL(capturedUrl)
+      expect(url.searchParams.get('observed_user_id')).toBe('35')
+
+      expect(transformApiToInternalItem).toHaveBeenCalledTimes(1)
+      expect(transformApiToInternalItem.mock.calls[0][4]).toEqual(expectedPushForwardTimeOptions)
     })
   })
 

--- a/ui/shared/planner/actions/__tests__/sidebar-actions.test.js
+++ b/ui/shared/planner/actions/__tests__/sidebar-actions.test.js
@@ -21,6 +21,7 @@ import {setupServer} from 'msw/node'
 import moment from 'moment-timezone'
 import MockDate from 'mockdate'
 import {initialize} from '../../utilities/alertUtils'
+import {transformApiToInternalItem} from '../../utilities/apiUtils'
 
 import * as Actions from '../sidebar-actions'
 
@@ -72,6 +73,7 @@ function mockGetState(overrides) {
     timeZone: 'UTC',
     courses: [],
     groups: [],
+    pushForwardTimeOptions: {enabled: true, hour: 9},
   }
   return () => state
 }
@@ -106,6 +108,8 @@ describe('load items', () => {
   })
 
   it('dispatches SIDEBAR_ITEMS_LOADED with the proper payload on success', async () => {
+    transformApiToInternalItem.mockClear()
+
     server.use(
       http.get('*/api/v1/planner/items', () => {
         return new HttpResponse(JSON.stringify([{uniqueId: 1}, {uniqueId: 2}]), {
@@ -127,6 +131,8 @@ describe('load items', () => {
       payload: {items: ['transformed-1', 'transformed-2'], nextUrl: null},
     }
     expect(fakeDispatch).toHaveBeenCalledWith(expected)
+
+    expect(transformApiToInternalItem.mock.calls[0][4]).toEqual({enabled: true, hour: 9})
   })
 
   it('dispatches SIDEBAR_ITEMS_LOADED with the proper url on success', async () => {

--- a/ui/shared/planner/actions/loading-actions.js
+++ b/ui/shared/planner/actions/loading-actions.js
@@ -149,6 +149,7 @@ export function getFirstNewActivityDate(fromMoment) {
             getState().courses,
             getState().groups,
             getState().timeZone,
+            getState().pushForwardTimeOptions,
           )
           dispatch(foundFirstNewActivityDate(first.dateBucketMoment))
         }
@@ -507,6 +508,7 @@ function transformItems(loadingOptions, items) {
       loadingOptions.getState().courses,
       loadingOptions.getState().groups,
       loadingOptions.getState().timeZone,
+      loadingOptions.getState().pushForwardTimeOptions,
     ),
   )
 }

--- a/ui/shared/planner/actions/sidebar-actions.js
+++ b/ui/shared/planner/actions/sidebar-actions.js
@@ -45,7 +45,13 @@ export const DESIRED_ITEMS_TO_HAVE_LOADED = 14
 function handleSidebarLoadingResponse(response, dispatch, getState) {
   const nextUrl = findNextLink(response)
   const transformedItems = response.data.map(item =>
-    transformApiToInternalItem(item, getState().courses, getState().groups, getState().timeZone),
+    transformApiToInternalItem(
+      item,
+      getState().courses,
+      getState().groups,
+      getState().timeZone,
+      getState().pushForwardTimeOptions,
+    ),
   )
   dispatch(sidebarItemsLoaded({items: transformedItems, nextUrl}))
   dispatch(sidebarEnoughItemsLoaded())

--- a/ui/shared/planner/reducers/index.js
+++ b/ui/shared/planner/reducers/index.js
@@ -88,6 +88,33 @@ const firstNewActivityDate = handleAction(
   null,
 )
 
+const pushForwardTimeOptions = handleAction(
+  'INITIAL_OPTIONS',
+  (state, action) => {
+    const env = action.payload.env || {}
+
+    // This is intentionally defensive: the backing preference plumbing may not
+    // be available in all environments yet.
+    const candidate =
+      env?.PREFERENCES?.push_forward_time ||
+      env?.PREFERENCES?.planner_push_forward_time ||
+      env?.PUSH_FORWARD_TIME_OPTIONS ||
+      env?.PUSH_FORWARD_TIME
+
+    if (
+      candidate &&
+      typeof candidate.enabled === 'boolean' &&
+      typeof candidate.hour === 'number' &&
+      Number.isInteger(candidate.hour)
+    ) {
+      return candidate
+    }
+
+    return undefined
+  },
+  undefined,
+)
+
 const combinedReducers = combineReducers({
   courses,
   groups,
@@ -100,6 +127,7 @@ const combinedReducers = combineReducers({
   firstNewActivityDate,
   opportunities,
   singleCourse,
+  pushForwardTimeOptions,
   todo,
   ui,
   sidebar,


### PR DESCRIPTION
## Summary
- Threads optional `pushForwardTimeOptions` through planner Redux state and into `transformApiToInternalItem`.
- Passes the options for both the main planner loading path (`loading-actions.js`) and the To Do sidebar path (`sidebar-actions.js`).

## Why
- Enables the **integration** requirement for Feature 1 testing/verification (issue #8).
- Ensures observer-mode (`observed_user_id`) loading doesn’t break when bucketing transform is called with extra P.F.T. options (issue #7).

## What changed
- `ui/shared/planner/reducers/index.js`: adds `pushForwardTimeOptions` derived from `env` (defensive; falls back to undefined).
- `ui/shared/planner/actions/loading-actions.js`: passes `pushForwardTimeOptions` as the 5th argument.
- `ui/shared/planner/actions/sidebar-actions.js`: passes `pushForwardTimeOptions` as the 5th argument.

## Tests
- `yarn test ui/shared/planner/actions/__tests__/loading-actions.1.test.js`
- `yarn test ui/shared/planner/actions/__tests__/sidebar-actions.test.js`

## Traceability
- `agents/analyze-repo.md`: validate close to change; planner load/transform is centralized in `transformApiToInternalItem`.

## Follow-ups (still open)
- Manual/exploratory checklist for preference toggle in a running planner.
- Preference storage wiring (OQ-2) + observer-mode bucketing semantics if product decides observer-specific preference rules.
