### PR TITLE
Planner: persist P.F.T. preference in user settings + API

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -436,6 +436,7 @@ class UsersController < ApplicationController
                    dashboard_view: @current_user.dashboard_view(@domain_root_account),
                    hide_dashcard_color_overlays: @current_user.preferences[:hide_dashcard_color_overlays],
                    custom_colors: @current_user.custom_colors,
+                   push_forward_time: @current_user.push_forward_time,
                    learner_dashboard_tab_selection: @current_user.get_preference(:learner_dashboard_tab_selection) || "dashboard",
                    widget_dashboard_config: educator_config
                  },
@@ -454,6 +455,7 @@ class UsersController < ApplicationController
                    dashboard_view: @current_user.dashboard_view(@domain_root_account),
                    hide_dashcard_color_overlays: @current_user.preferences[:hide_dashcard_color_overlays],
                    custom_colors: @current_user.custom_colors,
+                   push_forward_time: @current_user.push_forward_time,
                    learner_dashboard_tab_selection: @current_user.get_preference(:learner_dashboard_tab_selection) || "dashboard",
                    widget_dashboard_config:
                  },
@@ -510,7 +512,8 @@ class UsersController < ApplicationController
              PREFERENCES: {
                dashboard_view: @current_user.dashboard_view(@domain_root_account),
                hide_dashcard_color_overlays: @current_user.preferences[:hide_dashcard_color_overlays],
-               custom_colors: @current_user.custom_colors
+               custom_colors: @current_user.custom_colors,
+               push_forward_time: @current_user.push_forward_time,
              },
              STUDENT_PLANNER_ENABLED: planner_enabled?,
              STUDENT_PLANNER_COURSES: planner_enabled? && map_courses_for_menu(@current_user.courses_with_primary_enrollment),
@@ -1795,6 +1798,13 @@ class UsersController < ApplicationController
   # @argument widget_dashboard_dark_mode [Boolean]
   #   If true, enables the dark color theme for the widget dashboard.
   #
+  # @argument push_forward_time_enabled [Boolean]
+  #   When true, planner items due before push_forward_time_hour are bucketed
+  #   to the previous calendar day.
+  #
+  # @argument push_forward_time_hour [Integer]
+  #   Local hour (0-23) used as the Push Forward Time threshold when enabled.
+  #
   # @example_request
   #
   #   curl 'https://<canvas>/api/v1/users/<user_id>/settings \
@@ -1808,7 +1818,7 @@ class UsersController < ApplicationController
     when request.get?
       return unless authorized_action(user, @current_user, :read)
 
-      render json: BOOLEAN_PREFS.index_with { |pref| !!user.preferences[pref] }
+      render json: user_settings_json(user)
     when request.put?
       return unless authorized_action(user, @current_user, [:manage, :manage_user_details])
 
@@ -1816,10 +1826,30 @@ class UsersController < ApplicationController
         user.preferences[pref] = value_to_boolean(params[pref]) unless params[pref].nil?
       end
 
+      if params.key?(:push_forward_time_enabled) || params.key?(:push_forward_time_hour)
+        current = user.push_forward_time
+        enabled = if params.key?(:push_forward_time_enabled)
+                    value_to_boolean(params[:push_forward_time_enabled])
+                  else
+                    current&.fetch(:enabled, false)
+                  end
+        hour = if params.key?(:push_forward_time_hour)
+                 params[:push_forward_time_hour].to_i
+               else
+                 current&.fetch(:hour, 22)
+               end
+
+        unless hour.between?(0, 23)
+          return render(json: { message: "push_forward_time_hour must be between 0 and 23" }, status: :bad_request)
+        end
+
+        user.push_forward_time = { enabled:, hour: }
+      end
+
       respond_to do |format|
         format.json do
           if user.save
-            render json: BOOLEAN_PREFS.index_with { |pref| !!user.preferences[pref] }
+            render json: user_settings_json(user)
           else
             render(json: user.errors, status: :bad_request)
           end
@@ -1827,6 +1857,13 @@ class UsersController < ApplicationController
       end
     end
   end
+
+  def user_settings_json(user)
+    BOOLEAN_PREFS.index_with { |pref| !!user.preferences[pref] }.merge(
+      push_forward_time: user.push_forward_time
+    )
+  end
+  private :user_settings_json
 
   def get_new_user_tutorial_statuses
     user = api_find(User, params[:id])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2029,6 +2029,21 @@ class User < ApplicationRecord
     preferences[:dashboard_view] = new_dashboard_view
   end
 
+  # Push Forward Time (P.F.T.) planner bucketing preference.
+  # Returns { enabled: Boolean, hour: Integer } when valid, else nil.
+  def push_forward_time
+    normalize_push_forward_time(preferences[:push_forward_time])
+  end
+
+  def push_forward_time=(value)
+    if value.nil?
+      preferences.delete(:push_forward_time)
+    else
+      normalized = normalize_push_forward_time(value)
+      preferences[:push_forward_time] = normalized if normalized
+    end
+  end
+
   def all_course_nicknames(courses = nil)
     if preferences[:course_nicknames] == UserPreferenceValue::EXTERNAL
       shard.activate do
@@ -4121,4 +4136,20 @@ class User < ApplicationRecord
   def all_calendar_events
     CalendarEvent.where(user: self).or(CalendarEvent.where(context: self))
   end
+
+  def normalize_push_forward_time(raw)
+    return nil if raw.blank?
+    return nil unless raw.is_a?(Hash)
+
+    enabled = raw[:enabled]
+    enabled = raw["enabled"] if enabled.nil?
+    hour = raw[:hour]
+    hour = raw["hour"] if hour.nil?
+
+    return nil unless [true, false].include?(enabled)
+    return nil unless hour.is_a?(Integer) && hour.between?(0, 23)
+
+    { enabled:, hour: }
+  end
+  private :normalize_push_forward_time
 end

--- a/spec/apis/v1/users_api_spec.rb
+++ b/spec/apis/v1/users_api_spec.rb
@@ -2819,6 +2819,14 @@ describe "Users API", type: :request do
         expect(json["hide_dashcard_color_overlays"]).to be true
         expect(json["comment_library_suggestions_enabled"]).to be false
       end
+
+      it "is able to update push forward time settings" do
+        json = api_call(:put, path, path_options, push_forward_time_enabled: true, push_forward_time_hour: 21)
+        expect(json["push_forward_time"]).to eql({ "enabled" => true, "hour" => 21 })
+
+        json = api_call(:get, path, path_options)
+        expect(json["push_forward_time"]).to eql({ "enabled" => true, "hour" => 21 })
+      end
     end
 
     context "a student" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5106,6 +5106,34 @@ describe User do
     end
   end
 
+  describe "#push_forward_time" do
+    before do
+      user_factory(active_all: true)
+    end
+
+    it "returns nil when preference is unset" do
+      expect(@user.push_forward_time).to be_nil
+    end
+
+    it "returns normalized hash when preference is valid" do
+      @user.push_forward_time = { enabled: true, hour: 21 }
+      @user.save!
+      expect(@user.push_forward_time).to eql({ enabled: true, hour: 21 })
+    end
+
+    it "returns nil for invalid stored preference" do
+      @user.preferences[:push_forward_time] = { enabled: true, hour: 25 }
+      expect(@user.push_forward_time).to be_nil
+    end
+
+    it "clears preference when assigned nil" do
+      @user.push_forward_time = { enabled: false, hour: 22 }
+      @user.save!
+      @user.push_forward_time = nil
+      expect(@user.preferences[:push_forward_time]).to be_nil
+    end
+  end
+
   describe "user_can_edit_name?" do
     before(:once) do
       user_with_pseudonym

--- a/ui/shared/global/env/EnvCommon.d.ts
+++ b/ui/shared/global/env/EnvCommon.d.ts
@@ -176,6 +176,7 @@ export interface EnvCommon {
   PREFERENCES?: {
     hide_dashcard_color_overlays: boolean
     custom_colors: unknown
+    push_forward_time?: {enabled: boolean; hour: number} | null
   }
 
   SENTRY_FRONTEND?: {

--- a/ui/shared/planner/reducers/__tests__/index.test.js
+++ b/ui/shared/planner/reducers/__tests__/index.test.js
@@ -43,3 +43,45 @@ it('clones the first new activity date moment', () => {
   })
   expect(nextState.firstNewActivityDate).not.toBe(mockMoment)
 })
+
+it('reads push_forward_time from INITIAL_OPTIONS env preferences', () => {
+  const nextState = rootReducer(
+    {},
+    {
+      type: 'INITIAL_OPTIONS',
+      payload: {
+        env: {
+          MOMENT_LOCALE: 'en',
+          TIMEZONE: 'UTC',
+          STUDENT_PLANNER_GROUPS: [],
+          current_user: {id: 1, display_name: 'Test User'},
+          PREFERENCES: {
+            push_forward_time: {enabled: true, hour: 9},
+          },
+        },
+      },
+    },
+  )
+  expect(nextState.pushForwardTimeOptions).toEqual({enabled: true, hour: 9})
+})
+
+it('ignores invalid push_forward_time preference values', () => {
+  const nextState = rootReducer(
+    {},
+    {
+      type: 'INITIAL_OPTIONS',
+      payload: {
+        env: {
+          MOMENT_LOCALE: 'en',
+          TIMEZONE: 'UTC',
+          STUDENT_PLANNER_GROUPS: [],
+          current_user: {id: 1, display_name: 'Test User'},
+          PREFERENCES: {
+            push_forward_time: {enabled: true, hour: 9.5},
+          },
+        },
+      },
+    },
+  )
+  expect(nextState.pushForwardTimeOptions).toBeNull()
+})

--- a/ui/shared/planner/reducers/index.js
+++ b/ui/shared/planner/reducers/index.js
@@ -110,9 +110,9 @@ const pushForwardTimeOptions = handleAction(
       return candidate
     }
 
-    return undefined
+    return null
   },
-  undefined,
+  null,
 )
 
 const combinedReducers = combineReducers({


### PR DESCRIPTION
## Summary
- Persists Push Forward Time (P.F.T.) in `user.preferences[:push_forward_time]` as `{ enabled, hour }`.
- Exposes validated preference via `ENV.PREFERENCES.push_forward_time` on dashboard loads.
- Extends `PUT/GET /api/v1/users/:id/settings` with `push_forward_time_enabled` and `push_forward_time_hour` params.
- Fixes `pushForwardTimeOptions` reducer default state (`null` instead of invalid `undefined`).

## Why
- Resolves **OQ-2** (issue #10): source of truth for P.F.T. preference is user settings, threaded into planner via existing reducer from PR #15.

## Tests
- `bundle exec rspec spec/models/user_spec.rb -e push_forward_time`
- `bundle exec rspec spec/apis/v1/users_api_spec.rb -e "push forward time"`
- `yarn test ui/shared/planner/reducers/__tests__/index.test.js`

## Follow-ups
- Settings UI toggle/time picker (still out of scope per FR).
- OQ-3: observee mode — whose preference applies when viewing observed student planner.
- Manual verification checklist (issue #8).
