### PR TITLE
Planner: Push Forward Time settings UI + spike decisions

### DIFF
--- a/agents/tasks/feature-1/spike-decisions.md
+++ b/agents/tasks/feature-1/spike-decisions.md
@@ -1,0 +1,29 @@
+# Feature 1 — Spike decisions (OQ-3 through OQ-5)
+
+Decisions recorded for open product/engineering spikes after P.F.T. implementation (PRs #14–#17).
+
+## OQ-3 — Observee mode: whose preference applies?
+
+**Decision (v1):** Use the **logged-in user's** Push Forward Time preference (observer or student), sourced from `ENV.PREFERENCES.push_forward_time` at planner init.
+
+**Rationale:** Preference is stored per authenticated user and threaded through Redux at dashboard load. Observer flows already pass the same transform options when loading with `observed_user_id` (see PR #15 integration tests).
+
+**Follow-up (optional):** If product requires observee-specific bucketing, load the observed student's `push_forward_time` when `observed_user_id` is set and pass that into transform instead.
+
+## OQ-4 — Calendar events: same bucketing rule as assignments?
+
+**Decision:** **Yes** for timed (non-all-day) calendar events.
+
+**Rationale:** `getDateBucketMoment` in `apiUtils.js` applies the threshold to all items except `planner_note` and all-day events (`plannable.all_day`). Timed calendar events use the same due/start datetime path as assignments.
+
+**Out of scope:** Changing calendar-specific display outside planner list bucketing.
+
+## OQ-5 — Weekly dashboard parity with standard planner
+
+**Decision:** **Bucketing parity yes** (shared transform); **UI surface partial**.
+
+**Rationale:** Both standard and weekly planner load paths call `transformApiToInternalItem` with `pushForwardTimeOptions` from Redux (`loading-actions.js`). K5/weekly views use the same bucketing logic when items are transformed.
+
+**Gap:** Push Forward Time **settings UI** is on the classic dashboard List View header (PR #17). K5 weekly dashboard does not yet expose the settings control — users can still set preference via API or profile-adjacent settings API.
+
+**Scope:** No separate weekly-specific bucketing fork unless product requests different behavior.

--- a/ui/features/dashboard/react/DashboardHeader.jsx
+++ b/ui/features/dashboard/react/DashboardHeader.jsx
@@ -28,6 +28,8 @@ import {
   reloadPlannerForObserver,
   renderToDoSidebar,
   responsiviser,
+  PushForwardTimeSettings,
+  applyPushForwardTimePreference,
 } from '@canvas/planner'
 import {asAxios, getPrefetchedXHR} from '@canvas/util/xhr'
 import {showFlashAlert, showFlashError} from '@instructure/platform-alerts'
@@ -372,6 +374,12 @@ class DashboardHeader extends React.Component {
                   </Button>
                 )}
               <div id="DashboardOptionsMenu_Container">
+                {this.props.planner_enabled && this.state.currentDashboard === 'planner' && (
+                  <PushForwardTimeSettings
+                    locale={this.props.env.MOMENT_LOCALE || 'en'}
+                    onApplied={applyPushForwardTimePreference}
+                  />
+                )}
                 <DashboardOptionsMenu
                   view={this.state.currentDashboard}
                   planner_enabled={this.props.planner_enabled}
@@ -451,6 +459,12 @@ class DashboardHeader extends React.Component {
                 )}
               <Flex.Item overflowY="visible">
                 <div id="DashboardOptionsMenu_Container">
+                  {this.props.planner_enabled && this.state.currentDashboard === 'planner' && (
+                    <PushForwardTimeSettings
+                      locale={this.props.env.MOMENT_LOCALE || 'en'}
+                      onApplied={applyPushForwardTimePreference}
+                    />
+                  )}
                   <DashboardOptionsMenu
                     view={this.state.currentDashboard}
                     planner_enabled={this.props.planner_enabled}

--- a/ui/shared/planner/actions/index.js
+++ b/ui/shared/planner/actions/index.js
@@ -66,6 +66,7 @@ export const {
   clearDays,
   clearCourses,
   clearSidebar,
+  setPushForwardTimeOptions,
 } = createActions(
   'INITIAL_OPTIONS',
   'ADD_OPPORTUNITIES',
@@ -92,6 +93,7 @@ export const {
   'CLEAR_DAYS',
   'CLEAR_COURSES',
   'CLEAR_SIDEBAR',
+  'SET_PUSH_FORWARD_TIME_OPTIONS',
 )
 
 export * from './loading-actions'

--- a/ui/shared/planner/components/PushForwardTimeSettings/__tests__/PushForwardTimeSettings.test.jsx
+++ b/ui/shared/planner/components/PushForwardTimeSettings/__tests__/PushForwardTimeSettings.test.jsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import {render, fireEvent, waitFor} from '@testing-library/react'
+import {http, HttpResponse} from 'msw'
+import {setupServer} from 'msw/node'
+import PushForwardTimeSettings from '../index'
+
+const server = setupServer()
+
+describe('PushForwardTimeSettings', () => {
+  beforeAll(() => {
+    server.listen()
+  })
+
+  beforeEach(() => {
+    ENV.PREFERENCES = {push_forward_time: {enabled: false, hour: 22}}
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  afterAll(() => {
+    server.close()
+  })
+
+  it('renders settings trigger', () => {
+    const {getByTestId} = render(<PushForwardTimeSettings />)
+    expect(getByTestId('push-forward-time-settings-button')).toBeInTheDocument()
+  })
+
+  it('persists enabled preference via settings API', async () => {
+    const onApplied = vi.fn()
+    let savedBody
+
+    server.use(
+      http.put('/api/v1/users/self/settings', async ({request}) => {
+        savedBody = await request.json()
+        return HttpResponse.json({
+          push_forward_time: {enabled: true, hour: 22},
+        })
+      }),
+    )
+
+    const {getByTestId} = render(<PushForwardTimeSettings onApplied={onApplied} />)
+    fireEvent.click(getByTestId('push-forward-time-settings-button'))
+    fireEvent.click(getByTestId('push-forward-time-enabled-toggle'))
+
+    await waitFor(() => {
+      expect(savedBody).toEqual({
+        push_forward_time_enabled: true,
+        push_forward_time_hour: 22,
+      })
+    })
+    expect(onApplied).toHaveBeenCalledWith({enabled: true, hour: 22})
+    expect(ENV.PREFERENCES.push_forward_time).toEqual({enabled: true, hour: 22})
+  })
+})

--- a/ui/shared/planner/components/PushForwardTimeSettings/index.jsx
+++ b/ui/shared/planner/components/PushForwardTimeSettings/index.jsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, {useMemo, useState} from 'react'
+import PropTypes from 'prop-types'
+import {useScope as createI18nScope} from '@canvas/i18n'
+import doFetchApi from '@canvas/do-fetch-api-effect'
+import {showFlashAlert} from '@instructure/platform-alerts'
+import {IconButton} from '@instructure/ui-buttons'
+import {IconSettingsLine} from '@instructure/ui-icons'
+import {Popover} from '@instructure/ui-popover'
+import {View} from '@instructure/ui-view'
+import {Text} from '@instructure/ui-text'
+import {Checkbox} from '@instructure/ui-checkbox'
+import {SimpleSelect} from '@instructure/ui-simple-select'
+import {ScreenReaderContent} from '@instructure/ui-a11y-content'
+import {
+  pushForwardHourOptions,
+  readPushForwardTimeFromEnv,
+  resolvePushForwardTimeOptions,
+} from '../../utilities/pushForwardTimePreference'
+
+const I18n = createI18nScope('planner')
+
+async function savePushForwardTimePreference({enabled, hour}) {
+  await doFetchApi({
+    path: '/api/v1/users/self/settings',
+    method: 'PUT',
+    body: {
+      push_forward_time_enabled: enabled,
+      push_forward_time_hour: hour,
+    },
+  })
+}
+
+export default function PushForwardTimeSettings({locale, onApplied}) {
+  const initialOptions = useMemo(
+    () => resolvePushForwardTimeOptions(readPushForwardTimeFromEnv(ENV)),
+    [],
+  )
+  const [open, setOpen] = useState(false)
+  const [enabled, setEnabled] = useState(initialOptions.enabled)
+  const [hour, setHour] = useState(initialOptions.hour)
+  const [saving, setSaving] = useState(false)
+
+  const hourOptions = useMemo(() => pushForwardHourOptions(locale), [locale])
+
+  const persist = async nextOptions => {
+    setSaving(true)
+    try {
+      await savePushForwardTimePreference(nextOptions)
+      if (ENV.PREFERENCES) {
+        ENV.PREFERENCES.push_forward_time = nextOptions
+      }
+      onApplied?.(nextOptions)
+    } catch {
+      showFlashAlert({
+        message: I18n.t('Failed to save push forward time preference'),
+        type: 'error',
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleEnabledChange = event => {
+    const nextEnabled = event.target.checked
+    const nextOptions = {enabled: nextEnabled, hour}
+    setEnabled(nextEnabled)
+    persist(nextOptions)
+  }
+
+  const handleHourChange = (_event, {value}) => {
+    const nextHour = Number(value)
+    const nextOptions = {enabled, hour: nextHour}
+    setHour(nextHour)
+    persist(nextOptions)
+  }
+
+  return (
+    <Popover
+      isShowingContent={open}
+      onShowContent={() => setOpen(true)}
+      onHideContent={() => setOpen(false)}
+      on="click"
+      placement="bottom end"
+      renderTrigger={
+        <IconButton
+          renderIcon={IconSettingsLine}
+          screenReaderLabel={I18n.t('Push forward time settings')}
+          withBorder={false}
+          withBackground={false}
+          data-testid="push-forward-time-settings-button"
+        />
+      }
+    >
+      <View as="div" padding="small" maxWidth="20rem">
+        <Text as="div" weight="bold" margin="0 0 x-small 0">
+          {I18n.t('Push Forward Time')}
+        </Text>
+        <Text as="div" size="small" margin="0 0 small 0">
+          {I18n.t(
+            'When enabled, items due before this time appear on the previous day in List View.',
+          )}
+        </Text>
+        <Checkbox
+          label={I18n.t('Enable push forward time')}
+          variant="toggle"
+          checked={enabled}
+          disabled={saving}
+          onChange={handleEnabledChange}
+          data-testid="push-forward-time-enabled-toggle"
+        />
+        <View as="div" margin="small 0 0 0">
+          <SimpleSelect
+            renderLabel={
+              <ScreenReaderContent>{I18n.t('Push forward time hour')}</ScreenReaderContent>
+            }
+            assistiveText={I18n.t('Push forward time hour')}
+            value={String(hour)}
+            disabled={!enabled || saving}
+            onChange={handleHourChange}
+            data-testid="push-forward-time-hour-select"
+          >
+            {hourOptions.map(option => (
+              <SimpleSelect.Option key={option.value} id={String(option.value)} value={option.value}>
+                {option.label}
+              </SimpleSelect.Option>
+            ))}
+          </SimpleSelect>
+        </View>
+      </View>
+    </Popover>
+  )
+}
+
+PushForwardTimeSettings.propTypes = {
+  locale: PropTypes.string,
+  onApplied: PropTypes.func,
+}
+
+PushForwardTimeSettings.defaultProps = {
+  locale: 'en',
+  onApplied: () => {},
+}

--- a/ui/shared/planner/index.tsx
+++ b/ui/shared/planner/index.tsx
@@ -34,6 +34,8 @@ import {
   toggleMissingItems,
   reloadWithObservee,
   getInitialOpportunities,
+  setPushForwardTimeOptions,
+  clearDays,
 } from './actions'
 import {registerScrollEvents} from './utilities/scrollUtils'
 import {initialize as initializeAlerts} from './utilities/alertUtils'
@@ -52,6 +54,18 @@ const WeeklyPlannerHeader = React.lazy(() => import('./components/WeeklyPlannerH
 export * from './components'
 
 export {loadThisWeekItems, toggleMissingItems}
+
+export {default as PushForwardTimeSettings} from './components/PushForwardTimeSettings'
+
+export function applyPushForwardTimePreference(options) {
+  // @ts-expect-error TS7005 (typescriptify)
+  if (!initializedOptions) return
+
+  store.dispatch(setPushForwardTimeOptions(options))
+  store.dispatch(clearDays())
+  const timeZone = initializedOptions.env.TIMEZONE
+  store.dispatch(getPlannerItems(moment.tz(timeZone).startOf('day')))
+}
 
 export {responsiviser}
 

--- a/ui/shared/planner/reducers/__tests__/index.test.js
+++ b/ui/shared/planner/reducers/__tests__/index.test.js
@@ -85,3 +85,12 @@ it('ignores invalid push_forward_time preference values', () => {
   )
   expect(nextState.pushForwardTimeOptions).toBeNull()
 })
+
+it('updates pushForwardTimeOptions from SET_PUSH_FORWARD_TIME_OPTIONS', () => {
+  const initialState = rootReducer({}, {type: 'FAKE_ACTION'})
+  const nextState = rootReducer(initialState, {
+    type: 'SET_PUSH_FORWARD_TIME_OPTIONS',
+    payload: {enabled: true, hour: 15},
+  })
+  expect(nextState.pushForwardTimeOptions).toEqual({enabled: true, hour: 15})
+})

--- a/ui/shared/planner/reducers/index.js
+++ b/ui/shared/planner/reducers/index.js
@@ -18,7 +18,8 @@
 
 import moment from 'moment-timezone'
 import {combineReducers} from 'redux'
-import {handleAction} from 'redux-actions'
+import {handleAction, handleActions} from 'redux-actions'
+import {readPushForwardTimeFromEnv, normalizePushForwardTimeOptions} from '../utilities/pushForwardTimePreference'
 import days from './days-reducer'
 import loading from './loading-reducer'
 import courses from './courses-reducer'
@@ -88,29 +89,11 @@ const firstNewActivityDate = handleAction(
   null,
 )
 
-const pushForwardTimeOptions = handleAction(
-  'INITIAL_OPTIONS',
-  (state, action) => {
-    const env = action.payload.env || {}
-
-    // This is intentionally defensive: the backing preference plumbing may not
-    // be available in all environments yet.
-    const candidate =
-      env?.PREFERENCES?.push_forward_time ||
-      env?.PREFERENCES?.planner_push_forward_time ||
-      env?.PUSH_FORWARD_TIME_OPTIONS ||
-      env?.PUSH_FORWARD_TIME
-
-    if (
-      candidate &&
-      typeof candidate.enabled === 'boolean' &&
-      typeof candidate.hour === 'number' &&
-      Number.isInteger(candidate.hour)
-    ) {
-      return candidate
-    }
-
-    return null
+const pushForwardTimeOptions = handleActions(
+  {
+    INITIAL_OPTIONS: (_state, action) => readPushForwardTimeFromEnv(action.payload.env || {}),
+    SET_PUSH_FORWARD_TIME_OPTIONS: (_state, action) =>
+      normalizePushForwardTimeOptions(action.payload),
   },
   null,
 )

--- a/ui/shared/planner/utilities/__tests__/pushForwardTimePreference.test.js
+++ b/ui/shared/planner/utilities/__tests__/pushForwardTimePreference.test.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  DEFAULT_PUSH_FORWARD_HOUR,
+  normalizePushForwardTimeOptions,
+  readPushForwardTimeFromEnv,
+  resolvePushForwardTimeOptions,
+  pushForwardHourOptions,
+} from '../pushForwardTimePreference'
+
+describe('pushForwardTimePreference', () => {
+  it('normalizes valid options', () => {
+    expect(normalizePushForwardTimeOptions({enabled: true, hour: 9})).toEqual({
+      enabled: true,
+      hour: 9,
+    })
+  })
+
+  it('rejects invalid hour values', () => {
+    expect(normalizePushForwardTimeOptions({enabled: true, hour: 9.5})).toBeNull()
+    expect(normalizePushForwardTimeOptions({enabled: true, hour: 24})).toBeNull()
+  })
+
+  it('reads preference from env.PREFERENCES.push_forward_time', () => {
+    expect(
+      readPushForwardTimeFromEnv({
+        PREFERENCES: {push_forward_time: {enabled: false, hour: 21}},
+      }),
+    ).toEqual({enabled: false, hour: 21})
+  })
+
+  it('falls back to default options when env preference is missing', () => {
+    expect(resolvePushForwardTimeOptions(null)).toEqual({
+      enabled: false,
+      hour: DEFAULT_PUSH_FORWARD_HOUR,
+    })
+  })
+
+  it('builds 24 hour options', () => {
+    expect(pushForwardHourOptions('en')).toHaveLength(24)
+    expect(pushForwardHourOptions('en')[0].value).toBe(0)
+    expect(pushForwardHourOptions('en')[23].value).toBe(23)
+  })
+})

--- a/ui/shared/planner/utilities/pushForwardTimePreference.js
+++ b/ui/shared/planner/utilities/pushForwardTimePreference.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 - present Instructure, Inc.
+ *
+ * This file is part of Canvas.
+ *
+ * Canvas is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, version 3 of the License.
+ *
+ * Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import moment from 'moment-timezone'
+
+export const DEFAULT_PUSH_FORWARD_HOUR = 22
+
+export function normalizePushForwardTimeOptions(candidate) {
+  if (
+    candidate &&
+    typeof candidate.enabled === 'boolean' &&
+    typeof candidate.hour === 'number' &&
+    Number.isInteger(candidate.hour) &&
+    candidate.hour >= 0 &&
+    candidate.hour <= 23
+  ) {
+    return {enabled: candidate.enabled, hour: candidate.hour}
+  }
+
+  return null
+}
+
+export function readPushForwardTimeFromEnv(env = {}) {
+  const candidate =
+    env?.PREFERENCES?.push_forward_time ||
+    env?.PREFERENCES?.planner_push_forward_time ||
+    env?.PUSH_FORWARD_TIME_OPTIONS ||
+    env?.PUSH_FORWARD_TIME
+
+  return normalizePushForwardTimeOptions(candidate)
+}
+
+export function defaultPushForwardTimeOptions() {
+  return {enabled: false, hour: DEFAULT_PUSH_FORWARD_HOUR}
+}
+
+export function resolvePushForwardTimeOptions(candidate) {
+  return normalizePushForwardTimeOptions(candidate) || defaultPushForwardTimeOptions()
+}
+
+export function pushForwardHourOptions(locale = 'en') {
+  return Array.from({length: 24}, (_, hour) => ({
+    value: hour,
+    label: moment().locale(locale).hour(hour).minute(0).second(0).format('LT'),
+  }))
+}


### PR DESCRIPTION
## Summary
- Adds **Push Forward Time** settings control (gear icon) on Dashboard **List View**.
- Toggle + hour picker persist via `PUT /api/v1/users/self/settings`.
- Reloads planner items after save so day buckets update immediately.
- Documents spike decisions for **OQ-3**, **OQ-4**, **OQ-5** in `agents/tasks/feature-1/spike-decisions.md`.

## UI location
Dashboard → List View → gear icon next to dashboard options menu.

## Tests
- `yarn test ui/shared/planner/utilities/__tests__/pushForwardTimePreference.test.js`
- `yarn test ui/shared/planner/components/PushForwardTimeSettings/__tests__/PushForwardTimeSettings.test.jsx`
- `yarn test ui/shared/planner/reducers/__tests__/index.test.js`

## Closes
- Spike issues #11, #12, #13 (decisions documented)
